### PR TITLE
amend pagination tests to cover new pagination in b55

### DIFF
--- a/features/step_definitions/pagination_step_definitions.rb
+++ b/features/step_definitions/pagination_step_definitions.rb
@@ -5,7 +5,10 @@ end
 
 Then(/^I can go to the next page \(page (\d+)\)$/) do |expected_page_num|
   click_link('Next page')
-  expect(next_page_number).to eq(expected_page_num.to_i + 1)
+  page_text = page.find('#pagination').text
+  actual_page_num = page_text.split(' ')
+  # This grabs the current page number
+  expect(actual_page_num[1].to_i).to eq(expected_page_num.to_i)
 end
 
 Then(/^I see we are on page (\d+)$/) do |expected_page_num|
@@ -14,7 +17,7 @@ end
 
 Then(/^I see the number of pages is (\d+)$/) do |expected_page_num|
   # These lines strip out the last number of the pagination number text.
-  page_text = page.find('.pagination-prev-next').text
+  page_text = page.find('#pagination').text
   actual_page_num = page_text.split(' ').last.to_i
   expect(actual_page_num).to eq expected_page_num.to_i
 end


### PR DESCRIPTION
This is to be merged after

https://github.com/LandRegistry/digital-register-frontend/pull/186

This covers testing for the frontend changes for B55 where we have made the pagination less confusing for the user.
